### PR TITLE
fixed inventory example for tower to match 3.1

### DIFF
--- a/content/workshops/ansible_tower/exercise2.0.adoc
+++ b/content/workshops/ansible_tower/exercise2.0.adoc
@@ -71,10 +71,9 @@ Fill a few variables out in an inventory file: `admin_password, pg_password, rab
 
 [subs=+quotes]
 ----
-[primary]
-localhost ansible_connection=local
 
-[secondary]
+[tower]
+localhost ansible_connection=local
 
 [database]
 
@@ -96,6 +95,7 @@ rabbitmq_cookie=cookiemonster
 
 # Needs to be true for fqdns and ip addresses
 rabbitmq_use_long_name=false
+
 ----
 
 === Step 7:


### PR DESCRIPTION
The current 3.0 inventory file doesn't match the syntax.  Some students have tried pasting it in entirety into their 3.1 server, causing it to fail installation.  