### PR TITLE
Hack scripts for project initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ branches:
     - docs
 
 install:
-  - gem install asciidoctor
-  - sudo pip install Pygments
+  - ./hack/init.sh
   - rm -rf public || exit 0
 
 script:

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ GITREPO="https://github.com/${GITUSER}/redhatgov.github.io/archive/docs.zip"
 ARCHIVE="$(printf "%s" "${GITREPO##*/}")"
 
 # Download and extract
-wget ${GITREPO} \
+wget $GITREPO \
 && temp="$(mktemp -d)" \
-&& unzip -d ${temp} ${ARCHIVE} \
-&& mkdir -p ${DIRPATH} \
-&& mv ${temp}/*/* ${DIRPATH} \
-&& rm -rf ${temp} ${ARCHIVE} \
-&& cd ${DIRPATH} \
-&& unset DIRPATH GITUSER GITREPO ARCHIVE
+&& unzip -d $temp $ARCHIVE \
+&& mkdir -p $DIRPATH \
+&& mv $temp/*/* $DIRPATH \
+&& rm -rf $temp $ARCHIVE \
+&& cd $DIRPATH \
+&& unset DIRPATH GITUSER GITREPO ARCHIVE temp
 ```
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -2,28 +2,61 @@
 
 [![Build Status](https://travis-ci.org/RedHatGov/redhatgov.github.io.svg?branch=docs)](https://travis-ci.org/RedHatGov/redhatgov.github.io)
 
+--------------------------------------------------------------------------------
 
-----
+[RedHatGov.io][redhatgov] is an open source collection of workshop materials that cover various topics relating to Red Hat's product portfolio.
 
-[RedHatGov.io][redhatgov] is an open source collection of workshop materials that
-cover various topics relating to Red Hat's product portfolio.
+--------------------------------------------------------------------------------
 
-----
+## Getting Started
 
-## To start developing
+To use this project, you'll need (at minimum):
 
-If you want to build RedHatGov.io right away:
+- [Hugo] >=0.20.7
 
-##### You have a working [Hugo environment][hugo].
+### Install
 
-    $ git clone https://github.com/RedHatGov/redhatgov.github.io
-    $ cd redhatgov.github.io
-    $ hugo server
+#### GNU/Linux, or macOS
+
+```sh
+#!/bin/bash
+
+git clone https://github.com/RedHatGov/redhatgov.github.io
+cd redhatgov.github.io
+```
+
+##### No `git`? No problem!
+
+```sh
+#!/bin/bash
+
+DIRPATH="${HOME}/Downloads/redhatgov.io"; GITUSER="RedHatGov"
+GITREPO="https://github.com/${GITUSER}/redhatgov.github.io/archive/docs.zip"
+ARCHIVE="$(printf "%s" "${GITREPO##*/}")"
+
+# Download and extract
+wget ${GITREPO} \
+&& temp="$(mktemp -d)" \
+&& unzip -d ${temp} ${ARCHIVE} \
+&& mkdir -p ${DIRPATH} \
+&& mv ${temp}/*/* ${DIRPATH} \
+&& rm -rf ${temp} ${ARCHIVE} \
+&& cd ${DIRPATH} \
+&& unset DIRPATH GITUSER GITREPO ARCHIVE
+```
+
+### Setup
+
+```sh
+#!/bin/bash
+
+source hack/init.sh
+hugo server
+```
 
 ## Contributing
 
-If you have content that you'd like to contribute, check out our
-[contribution guidelines for this project](CONTRIBUTING.md).
+If you have content that you'd like to contribute, check out our [contribution guidelines for this project](CONTRIBUTING.md).
 
-[redhatgov]: http://redhatgov.io/
 [hugo]: https://gohugo.io/overview/introduction/
+[redhatgov]: http://redhatgov.io/

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# This script is meant to be the entrypoint for Bash scripts to import all of the support
+# libraries at once in order to make Bash script preambles as minimal as possible. This script recur-
+# sively `source`s *.sh files in this dirs tree. As such, no files should be `source`ed outside
+# of this script to ensure that we do not attempt to overwrite read-only variables.
+
+# Stop script on NZEC
+set -e
+
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+# By default cmd1 | cmd2 returns exit code of cmd2 regardless of cmd1 success
+# this is causing it to fail
+set -o pipefail
+
+# Checks if command in hash table exists before executing it
+shopt -s checkhash
+
+INSTALL_DOC="https://gohugo.io/getting-started/installing#step-2-download-the-tarball"
+SCRIPT_NAME=$(basename "$0")
+HUGO_BINARY=${HUGO_BINARY:-"hugo"}
+HUGO_SEMVER="0.29"
+__PLATFORM="unknown"
+__MACHBITS="unknown"
+__BASHPROF="unknown"
+__UNAMESTR="$(uname)"
+__MACHARCH="$(uname -m)"
+
+# Verify supported system
+if [[ "$__UNAMESTR" == "Linux" ]]; then
+ __PLATFORM="Linux"
+ __BASHPROF=".bashrc"
+elif [[ "$__UNAMESTR" == "Darwin" ]]; then
+ __PLATFORM="macOS"
+ __BASHPROF=".bash_profile"
+fi
+
+if [[ "${__PLATFORM}" == "unknown" || "${__BASHPROF}" == "unknown" ]]; then
+ echo "Unknown platform: script should exit" && exit 1
+fi
+
+if [[ "${__MACHARCH}" == "x86_64" ]]; then
+ __MACHBITS="64bit"
+fi
+
+if [[ "$__MACHBITS" == "unknown" ]]; then
+ echo "Unsupported architecture: stoping script" && exit 1
+fi
+
+# Resolve $SOURCE until the file is no longer a symlink
+SOURCE="`test -L ${BASH_SOURCE[0]} \
+&& readlink ${BASH_SOURCE[0]} \
+|| echo ${BASH_SOURCE[0]}`"
+
+while [ -h "$SOURCE" ]; do
+ DIRPATH="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+ SOURCE="$(readlink "$SOURCE")"
+
+ # If $SOURCE was a relative symlink, we need to resolve it relative to the path
+ # where the symlink file was located.
+ [[ $SOURCE != /* ]] && SOURCE="$DIRPATH/$SOURCE"
+done
+
+DIRPATH="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIRPATH/lib/common.sh"
+
+ABSPATH="$(get_absolute_path "$DIRPATH/..")"
+PROJECT="${PROJECT:-"${ABSPATH}"}"
+PROJECT_NAME="${PROJECT_NAME:-"${PROJECT##*/}"}"
+
+# Helpers
+load_library "${PROJECT:-"${ABSPATH}"}"
+
+# Check if hugo exists, if not install locally
+if ! hash hugo 2>/dev/null; then
+ HUGO_GIT_USER="gohugoio"; HUGO_GIT_PROJ="hugo"; HUGO_GIT_VERS="${HUGO_SEMVER:-"0.20.7"}"
+ HUGO_GIT_URIS="https://github.com/${HUGO_GIT_USER}/${HUGO_GIT_PROJ}/releases/download/v${HUGO_GIT_VERS}"
+ HUGO_GIT_ARCS="${HUGO_GIT_PROJ}_${HUGO_GIT_VERS}_${__PLATFORM}-${__MACHBITS}.tar.gz"
+ HUGO_GIT_RELS=${HUGO_GIT_RELS:-"${HUGO_GIT_URIS}/${HUGO_GIT_ARCS}"}
+ HUGO_BIN_PATH="${PROJECT:-"${ABSPATH}"}/bin"
+ HUGO_BIN_FILE="${HUGO_BIN_PATH}/${HUGO_BINARY}"
+ HUGO_BIN_SYML="${HOME}/.local/bin/${HUGO_BINARY}"
+
+ # Download and unpack release archive
+ if [[ ! -f "${HUGO_BIN_FILE}" ]]; then
+  unarchive-download "${HUGO_GIT_RELS}" "${HUGO_BIN_PATH}"
+ fi
+
+ # Create symbolic link to binary file
+ ln -sf "${HUGO_BIN_FILE}" "${HUGO_BIN_SYML}"
+
+ # Reload session
+ source "${HOME}/${__BASHPROF}"
+fi
+
+if ! hash pip 2>/dev/null; then
+ temp=$(mktemp -d) \
+ && pushd ${temp} \
+ && wget https://bootstrap.pypa.io/get-pip.py \
+ && python get-pip.py --user \
+ && popd && rm -rf ${temp}
+fi
+
+pip install -q -U --user pip Pygments
+gem install -q --conservative --user-install asciidoctor

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+function get_absolute_path() {
+ local relative_path="$1"
+ local get_absolute_path
+
+ pushd "${relative_path}" >/dev/null
+ relative_path="$( pwd )"
+ if [[ -h "${relative_path}" ]]; then
+  get_absolute_path="$( readlink "${relative_path}" )"
+ else
+  get_absolute_path="${relative_path}"
+ fi
+ popd >/dev/null
+
+ echo "${get_absolute_path}"
+}
+
+function load_library() {
+ local library="$1/hack/lib"; shift || return 1
+ local library_files
+
+ # Concatenate library files
+ library_files=( $( find "${library}" -type f -name '*.sh' -not -path "*${library}/init.sh" ) )
+
+ # Load libraries into current shell
+ for library_file in "${library_files[@]}"; do
+  source "${library_file}"
+  libstr="${library_file##*\/}"
+  # printf "load_library: %s\n" "${libstr%.*}"
+ done
+
+ unset library_files library_file
+}

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function unarchive-download() {
+ local archive=$1
+ local targdir=$2; shift 2 || return 1
+ local arcname="$(printf "%s" "${archive##*/}")"
+ local arctype
+
+ if [[ ! -z "${arcname}" ]]; then
+  arctype="$(echo "${arcname}" | egrep -o "tar.gz")"
+ fi
+
+ if [[ "${arctype}" == "tar.gz" ]]; then
+  wget "${archive}" \
+  && mkdir -p "${targdir}" &>/dev/null \
+  && tar -xzf "${arcname}" -C "${targdir}" \
+  && rm -rf "${arcname}"
+ fi
+}


### PR DESCRIPTION
- Removed binary from repo to reduce size of checkout
- Added `hack`/ scripts to automate local `hugo` installation
- Updated README documentation for howto guidance
- Updated .travis.yml to not use sudo anymore

Items above will serve as baseline init scripts for future containerization.