### PR TITLE
Corrected oc command syntax in Lab1.

### DIFF
--- a/content/workshops/openshift_101_dcmetromap/lab1-welcome.md
+++ b/content/workshops/openshift_101_dcmetromap/lab1-welcome.md
@@ -70,7 +70,7 @@ You just created a project using the web console, let's tell the terminal comman
 > <i class="fa fa-terminal"></i> Type the following command to use the demo project:
 
 ```bash
-$ oc project demo-YOUR#
+$ oc new-project demo-YOUR#
 ```
 
 > <i class="fa fa-terminal"></i> Type the following command to show services, deployment configs, build configurations, and active deployments (this will come in handy later):


### PR DESCRIPTION
Corrected syntax for creating a new project using the oc command:

-$ oc project demo-YOUR#
+$ oc new-project demo-YOUR#