### PR TITLE
Fix events generation due to change in google-api-python-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - docs
+    - hotfix
 
 before_install:
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_3a2ffd558b46_key -iv $encrypted_3a2ffd558b46_iv -in secrets.tar.enc -out secrets.tar -d; fi'

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
-awesome-slugify
-google-api-python-client
-jinja2
-python-dateutil
+awesome-slugify==1.6.5
+google-api-python-client==1.7.1
+jinja2==2.10
+oauth2client==4.1.2
+python-dateutil==2.7.3


### PR DESCRIPTION
Previous builds were experiencing the following error:

Traceback (most recent call last):
  File "./import_events.py", line 13, in <module>
    from apiclient import discovery
  File "/usr/local/lib/python2.7/dist-packages/apiclient/__init__.py", line 11, in <module>
    'Previous version of google-api-python-client detected; due to a '
RuntimeError: Previous version of google-api-python-client detected; due to a packaging issue, we cannot perform an in-place upgrade. To repair, remove and reinstall this package, along with oauth2client and uritemplate. One can do this with pip via
  pip install -I google-api-python-client

This was due to a change in the google-api-python-client package. We got
bit by this because we did not specify exact versions of each package to
pull and therefore were always getting the latest.

I have added the install of oauth2client as it's now required by
google-api-python-client and also updated the requirements.txt file to
include exact versions to minimize the risk in the future.