### PR TITLE
Added Font Awesome Shortcode and Documentation

### DIFF
--- a/content/workshops/example/hugo_shortcodes.md
+++ b/content/workshops/example/hugo_shortcodes.md
@@ -159,6 +159,30 @@ var port = process.env.PORT || process.env.OPENSHIFT_NODEJS_PORT || 8080,
 {{< figure src="../images/lab1_oc_coolstore_dev1.png" title="OpenShift Coolstore" >}}
 
 
+### Font-Awesome Icons
+
+`fa` allows you to insert [Font Awesome](https://fontawesome.com/v4.7.0/icons/) icons into a Hugo Markdown page.
+
+#### Usage
+
+`fa` can be used the following ways:
+
+ * {{</* fa class="fa-dashboard" style="margin:1rem" */>}}
+ * {{</* fa "fa-dashboard" "margin:1rem" */>}}
+ * {{</* fa fa-dashboard  */>}}
+
+#### Example
+
+```bash
+ {{</* fa class="fa-dashboard" style="margin:1rem" */>}}
+ {{</* fa "fa-dashboard" "margin:1rem" */>}}
+ {{</* fa fa-dashboard  */>}}
+```
+
+#### Example output
+{{< fa fa-dashboard  >}}
+
+
 ### Twitter
 
 You want to include a single tweet into your blog post? Everything you need is the URL of the tweet, e.g.:

--- a/layouts/shortcodes/fa.html
+++ b/layouts/shortcodes/fa.html
@@ -1,0 +1,5 @@
+{{ if .IsNamedParams }}
+  <i class="fa {{ if .Get "class" }}{{ .Get "class" }}{{ else }}fa-surprise{{ end }}"{{ if .Get "style" }} style="{{ .Get "class" }}"{{ end }}></i>
+{{ else }}
+  <i class="fa {{ .Get 0 }}"{{ if len .Params | eq 2 }} style="{{ .Get 1 }}"{{ end }}></i>
+{{ end }}


### PR DESCRIPTION
Created new Font Awesome shortcode, use with {{< fa class="fa-dashboard" style="margin:1rem" >}} or {{< fa "fa-dashboard" "margin:1rem" >}}, OR simply {{< fa fa-dashboard >}}, arg2/style is optional

Documentation in Example Workshop > Hugo Shortcodes is updated to show an example as well as a link to the icon listings.

Provides #33 