### PR TITLE
Update lab2-byodocker.md

### DIFF
--- a/content/workshops/openshift_101_dcmetromap/lab2-byodocker.md
+++ b/content/workshops/openshift_101_dcmetromap/lab2-byodocker.md
@@ -72,7 +72,7 @@ Click "Deploy" then click "Close"
 > <i class="fa fa-terminal"></i> Try typing the following to see what is available to 'get':
 
 ```bash
-$ oc get
+$ oc get all
 ```
 
 > <i class="fa fa-terminal"></i> Now let's look at what our image stream has in it:


### PR DESCRIPTION
OC Commands have changed with 3.11 it seems.
"oc get" now returns:

````
student10@ip-172-31-31-72:~|⇒  oc get
You must specify the type of resource to get. Use "oc api-resources" for a complete list of supported resources.
error: Required resource not specified.
Use "oc explain <resource>" for a detailed description of that resource (e.g. oc explain pods).
See 'oc get -h' for help and examples.
student10@ip-172-31-31-72:~|⇒
````

"oc get all" is the new command.