### PR TITLE
Update links in secure software factory workshop to reference OCP 3.1…

### DIFF
--- a/content/workshops/secure_software_factory/lab03.md
+++ b/content/workshops/secure_software_factory/lab03.md
@@ -48,5 +48,5 @@ It might take a few minutes for all PODS to be deployed.
 <img src="../images/pipeline.png" width="900"><br/>
 
 [1]: https://stackoverflow.com/questions/28608015/continuous-integration-vs-continuous-delivery-vs-continuous-deployment
-[2]: https://docs.openshift.com/container-platform/3.9/dev_guide/openshift_pipeline.html
+[2]: https://docs.openshift.com/container-platform/3.11/dev_guide/openshift_pipeline.html
 {{< importPartial "footer/footer.html" >}}

--- a/content/workshops/secure_software_factory/lab05.md
+++ b/content/workshops/secure_software_factory/lab05.md
@@ -98,6 +98,6 @@ The .xml file refers to maven configurations for your application. The reference
 Click Save
 
 [1]: https://github.com/openshift/jenkins-client-plugin#examples
-[2]: https://docs.openshift.com/container-platform/3.9/dev_guide/builds/index.html#defining-a-buildconfig
-[3]: https://docs.openshift.com/container-platform/3.9/architecture/core_concepts/builds_and_image_streams.html#pipeline-build
+[2]: https://docs.openshift.com/container-platform/3.11/dev_guide/builds/index.html#defining-a-buildconfig
+[3]: https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#pipeline-build
 {{< importPartial "footer/footer.html" >}}

--- a/content/workshops/secure_software_factory/lab10.md
+++ b/content/workshops/secure_software_factory/lab10.md
@@ -90,5 +90,5 @@ Please delete the brackets you just added once testing is complete. We can add t
 ```
 Click Save
 
-[1]: https://docs.openshift.com/container-platform/3.9/architecture/core_concepts/builds_and_image_streams.html
+[1]: https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html
 {{< importPartial "footer/footer.html" >}}


### PR DESCRIPTION
The Secure Software Factory workshop is being done in OCP 3.11 now and references to documentation should point to 3.11 which is supported.