### PR TITLE
Fix SELinux workshop typo mistakes and etc.

### DIFF
--- a/content/workshops/selinux_policy/exercise1.1.adoc
+++ b/content/workshops/selinux_policy/exercise1.1.adoc
@@ -76,11 +76,11 @@ semanage permissive -l
 
 [source,bash]
 ----
+Builtin Permissive Types
+
 Customized Permissive Types
 
 httpd_t
-
-Builtin Permissive Types
 ----
 
 And again, we can change it back:
@@ -111,7 +111,7 @@ We have asked the `ausearch` utility to look for SELinux policies being loaded (
 ----
 type=PROCTITLE msg=audit(05/17/2019 23:47:54.147:1896) : proctitle=/sbin/load_policy 
 type=SYSCALL msg=audit(05/17/2019 23:47:54.147:1896) : arch=x86_64 syscall=write success=yes exit=3857474 a0=0x4 a1=0x7fb57e597000 a2=0x3adc42 a3=0x7ffc8bb993a0 items=0 ppid=16567 pid=16572 auid=ec2-user uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=1 comm=load_policy exe=/usr/sbin/load_policy subj=unconfined_u:unconfined_r:load_policy_t:s0-s0:c0.c1023 key=(null) 
-type=MAC_POLICY_LOAD msg=audit(05/17/2019 23:47:54.147:1896) : policy loaded auid=ec2-user ses=1
+type=MAC_POLICY_LOAD msg=audit(05/17/2019 23:47:54.147:1896) : auid=ec2-user ses=1 lsm=selinux res=yes
 -----
 
 Other useful searches include:

--- a/content/workshops/selinux_policy/exercise1.2.adoc
+++ b/content/workshops/selinux_policy/exercise1.2.adoc
@@ -24,12 +24,12 @@ ls -Z ~ec2-user/.vimrc
 
 [source,bash]
 ----
--rw-r--r--. ec2-user ec2-user unconfined_u:object_r:user_home_t:s0 /home/ec2-user/.vimrc
+unconfined_u:object_r:user_home_t:s0 /home/ec2-user/.vimrc
 ----
 
 Following the standard UNIX permissions, user and group information, the SELinux context attached to the file is displayed.  The fields are SELinux user (`unconfined_u`), role (`object_r`), type (`user_home_t`), and level (`s0`).  
 
-The SELinix user is not the same as the UNIX user, as it solely exists to associate a UNIX user to a set of roles.  This allows UNIX users to be constrained by SELinux policy.  In this case the `unconfined_u` user means that the user is mapped to the `__default__` SELinux login.  This means that the user is allowed to launch any application that standard filesystem permissions allow.  However, if that application has a defined domain transition, a confined domain will still apply to it.
+The SELinux user is not the same as the UNIX user, as it solely exists to associate a UNIX user to a set of roles.  This allows UNIX users to be constrained by SELinux policy.  In this case the `unconfined_u` user means that the user is mapped to the `__default__` SELinux login.  This means that the user is allowed to launch any application that standard filesystem permissions allow.  However, if that application has a defined domain transition, a confined domain will still apply to it.
 
 === Step 2: Domain transitions
 
@@ -45,12 +45,13 @@ ps -Z | grep yes
 unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 29448 pts/0 00:00:07 yes
 ----
 
-Here, you can see that the `yes` process is labled with the `unconfined_t` domain, indicating that it still has full `root` privileges, and can do whatever it wishes.
+Here, you can see that the `yes` process is labeled with the `unconfined_t` domain, indicating that it still has full `root` privileges, and can do whatever it wishes.
 
 On the other hand, if we launch the `passwd` utility, we will see a different story:
 
 {{< highlight bash >}}
 kill %1
+ps -Z | grep yes
 passwd ec2-user >/dev/null &
 ps -Z | grep passwd
 {{< /highlight >}}
@@ -85,7 +86,7 @@ ls -Z ./testaudit
 
 [source,bash]
 ----
--rw-------. root root system_u:object_r:httpd_sys_content_t:s0 ./testaudit
+system_u:object_r:httpd_sys_content_t:s0 ./testaudit
 ----
 
 And we can change it back, magically, with restorecon.  Note that this would have fixed the problem reported in our test AVC, by setting the context to `httpd_sys_content_t`:
@@ -97,7 +98,7 @@ ls -Z ./testaudit
 
 [source,bash]
 ----
--rw-------. root root system_u:object_r:admin_home_t:s0 ./testaudit
+system_u:object_r:admin_home_t:s0 ./testaudit
 ----
 
 I also slipped in `chcon`, which you can use to temporarily change the context on a file.

--- a/content/workshops/selinux_policy/exercise2.1.adoc
+++ b/content/workshops/selinux_policy/exercise2.1.adoc
@@ -70,7 +70,7 @@ rm tmp/testapp.mod tmp/testapp.mod.fc
 ./testapp_selinux.8
 ----
 
-In addition to compiling and loading the policy, the `testapp.sh` script also generates an RPM spec file, and builds a package, containing the policy for the app.  This makes it easy to redistribute the policy, when you have finishe dcreating it.  You can see this in the second part of the script output:
+In addition to compiling and loading the policy, the `testapp.sh` script also generates an RPM spec file, and builds a package, containing the policy for the app.  This makes it easy to redistribute the policy, when you have finished creating it.  You can see this in the second part of the script output:
 
 [source,bash]
 ----
@@ -143,8 +143,7 @@ sesearch -T -s init_t -t testapp_exec_t
 
 [source,bash]
 ----
-Found 1 semantic te rules:
-   type_transition init_t testapp_exec_t : process testapp_t;
+type_transition init_t testapp_exec_t : process testapp_t;
 ----
 
 The rule says that when any process labeled as `init_t` executes any binary labeled as `testapp_exec_t`, the newly-created process will be labeled as `testapp_t`.

--- a/content/workshops/selinux_policy/exercise2.2.adoc
+++ b/content/workshops/selinux_policy/exercise2.2.adoc
@@ -104,7 +104,8 @@ If we look at them both closely, we can see that the `testapp` process is being 
 SELinux interface definitions are located in `/usr/share/selinux/devel/include`, if you install the `selinux-policy-devel` package.  If we search for `/proc`, in files named `*.if` (interface definitions):
 
 {{< highlight bash >}}
-find . -type f -name "*.if" -exec grep -H '/proc' {} \;
+cd /usr/share/selinux/devel/include
+find . -type f -name "*.if" -exec grep -H '/proc' {} \; | grep "system state information"
 {{< /highlight >}}
 
 We see that in the results, there is a line that says:

--- a/content/workshops/selinux_policy/exercise2.3.adoc
+++ b/content/workshops/selinux_policy/exercise2.3.adoc
@@ -160,8 +160,8 @@ sudo ausearch -m AVC -ts recent | egrep 'tcp|udp' | audit2allow
 [source,bash] 
 ----
 #============= testapp_t ==============
-allow testapp_t self:tcp_socket { connect create getattr getopt };
-allow testapp_t self:udp_socket { connect create getattr };
+allow testapp_t self:tcp_socket { connect create getattr getopt setopt };
+allow testapp_t self:udp_socket { connect create getattr setopt };
 ----
 
 These rules look good, so go ahead and add them to your `testapp.te` file.


### PR DESCRIPTION
Fixing typo mistakes and outputs from terminal after summittest

Other important stuffs what fix and improve in workshop:

1.2
Step 1
"Following the standard UNIX permissions, user and group information, the SELinux context attached to the file is displayed."
FIX this sentence. This command show only SELinux context and and file path as I fix in this pull request.

2.1 to 2.4
After every added rule and recompiling testapp policy in workshop users check the how many AVC messages remaining via command
"sudo ausearch -m AVC -ts recent | grep ...."
but this command check AVC in 10 minute periods, so its possible that will show some number of AVC which were already there before compiled policy when we add new rule.
So it will be good to alert users in workshop, that they must wait some time, when the command "sudo ausearch -m AVC -ts recent | grep ...."
show 0 AVC.