### PR TITLE
Change wrapup weight for containers the hard way.

### DIFF
--- a/content/workshops/containers_the_hard_way/wrapup.adoc
+++ b/content/workshops/containers_the_hard_way/wrapup.adoc
@@ -1,7 +1,7 @@
 ---
 title: "Wrapup"
 workshops: containers_the_hard_way
-workshop_weight: 100
+workshop_weight: 95
 layout: lab
 ---
 


### PR DESCRIPTION
It would appear as if the pages published out of order. We are thinking the weights get sorted alphabetically, not numerically.