### PR TITLE
Remove the first 2 lines from ansible-galaxy generated files

### DIFF
--- a/content/workshops/ansible_automation/exercise1.5.adoc
+++ b/content/workshops/ansible_automation/exercise1.5.adoc
@@ -114,8 +114,6 @@ Add some default variables to your role in `roles/apache-simple/defaults/main.ym
 
 [source,bash]
 ----
----
-# defaults file for apache-simple
 apache_test_message: This is a test message
 apache_webserver_port: 80
 ----
@@ -126,8 +124,6 @@ Add some role-specific variables to your role in `roles/apache-simple/vars/main.
 
 [source,bash]
 ----
----
-# vars file for apache-simple
 httpd_packages:
   - httpd
   - mod_wsgi
@@ -154,8 +150,6 @@ Create your role handler in `roles/apache-simple/handlers/main.yml`.
 
 [source,bash]
 ----
----
-# handlers file for apache-simple
 - name: restart apache service
   service:
     name: httpd
@@ -169,8 +163,6 @@ Add tasks to your role in `roles/apache-simple/tasks/main.yml`.
 
 [source,bash]
 ----
----
-# tasks file for apache-simple
 - name: install httpd packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
The first 2 lines in these files are already present after running ansible-galaxy to create the role. Having them here and having the copy button which grabs the whole thing causes a yaml syntax error when the first 2 lines end up repeated twice. To verify, run the ansible-galaxy init role command and see that the --- and the comment line are already there.