### PR TITLE
Add the default username and password.

### DIFF
--- a/content/workshops/secure_software_factory/lab06.md
+++ b/content/workshops/secure_software_factory/lab06.md
@@ -84,6 +84,9 @@ View your gogs pod and click select the route (https://gogs...) to log into your
 
 Use the user name and password given to you by your instructor.
 
+Default Username: gogs
+Default Password: gogs
+
 <img src="../images/gogs_route.png" width="900"><br/>
 
 View the source of the openshift-tasks project in your gogs server.  


### PR DESCRIPTION
The default username and password are not listed in the lab. They are generally not changed nor set by the instructor. I don't even think there is a variable in the deployment tools to set this directly anyway.