### PR TITLE
Make site run on redhatgov.io and rhnaps.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "Red Hat | Public Sector"
-baseURL = "http://redhatgov.io/"
+baseURL = "/"
 theme = "redhatgov"
 languageCode = "en-us"
 metaDataFormat = "yaml"


### PR DESCRIPTION
This PR will make our workshop guides available at http://redhatgov.io and http://rhnaps.io

Tested this locally to validate that the change didn't break anything.