### PR TITLE
update skopeo copy

### DIFF
--- a/content/workshops/security_container_intro/lab06-inspecting.adoc
+++ b/content/workshops/security_container_intro/lab06-inspecting.adoc
@@ -143,7 +143,7 @@ skopeo inspect docker://registry.access.redhat.com/ubi8/ubi
 Skopeo can also copy images between two registries. See the `skopeo(1)` man page for details and give it a try. An example is shown below. To make this work, the proper image tags must exist and authentication to registries must be in place.
 [source,bash]
 ----
-skopeo copy {{< urifqdnrev "docker://" "node1" ":5000/ubi8/ubi" >}} {{< urifqdnrev "docker://" "node2" ":5000/ubi8/ubi" >}}
+skopeo copy {{< urifqdnrev "docker://" "node1" ":5000/fedora/latest" >}} {{< urifqdnrev "docker://" "node2" ":5000/fedora/latest" >}}
 ----
 ....
 Getting image source signatures


### PR DESCRIPTION
lab never had ubi8/ubi pulled down locally so not there to do a copy. it did have you pull down fedora/latest so tried that instead and it worked.