### PR TITLE
Hide older workshops - put into Retired menu item

### DIFF
--- a/content/jr-sa.html
+++ b/content/jr-sa.html
@@ -1,8 +1,8 @@
 ---
-title: Junior SA Program
-menu:
-  main:
-    weight: 90
+--title: Junior SA Program
+--menu:
+--  main:
+--    weight: 90
 ---
 <style>
  .display-1 {

--- a/content/workshops/ansible_tower_azure/_index.adoc
+++ b/content/workshops/ansible_tower_azure/_index.adoc
@@ -2,7 +2,7 @@
 title: Ansible Tower Workshop on Azure
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-magic
 ---
 

--- a/content/workshops/cloudforms41/_index.md
+++ b/content/workshops/cloudforms41/_index.md
@@ -3,7 +3,7 @@ title: CloudForms Workshops
 subtitle: Don't just read about what CloudForms 4.1 can do — try it for yourself with these workshops!
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-cloud
 ---
 

--- a/content/workshops/jdv_dev/_index.md
+++ b/content/workshops/jdv_dev/_index.md
@@ -2,7 +2,7 @@
 title: JBoss Data Virtualization Development
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-database
 ---
 

--- a/content/workshops/openshift_101_dcmetromap/_index.md
+++ b/content/workshops/openshift_101_dcmetromap/_index.md
@@ -2,7 +2,7 @@
 title: OpenShift 101 - DC Metro Map Workshop
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-map-o
 ---
 

--- a/content/workshops/rhosp_101/_index.md
+++ b/content/workshops/rhosp_101/_index.md
@@ -2,7 +2,7 @@
 title: Red Hat OpenStack Platform 101
 menu:
   main:
-    parent: workshops
+    parent: Retired
 ---
 
 # Red Hat OpenStack Platform 101

--- a/content/workshops/security_containers/_index.adoc
+++ b/content/workshops/security_containers/_index.adoc
@@ -2,7 +2,7 @@
 title: Container Security Workshop
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-lock
 ---
 

--- a/content/workshops/security_openshift/_index.adoc
+++ b/content/workshops/security_openshift/_index.adoc
@@ -2,7 +2,7 @@
 title: OpenShift Security Workshop
 menu:
   main:
-    parent: workshops
+    parent: Retired
     pre: fa fa-shield
 ---
 

--- a/content/workshops/source_to_image/_index.md
+++ b/content/workshops/source_to_image/_index.md
@@ -2,7 +2,7 @@
 title: Source to Image
 menu:
   main:
-    parent: workshops
+    parent: Retired
 ---
 
 # Source-to-Image - Accelerating Application Development


### PR DESCRIPTION
Changed file headers so that these workshops will not show on the main page.  Rather they will show up in a retired menu item.