### PR TITLE
Rhel8 updates feb2023

### DIFF
--- a/content/workshops/rhel_8/exercise1.7.adoc
+++ b/content/workshops/rhel_8/exercise1.7.adoc
@@ -28,7 +28,7 @@ The essential components of SCAP are:
 
 OpenSCAP is a project that implements tools for performing SCAP scans and remediating findings. +
 You can read more about the project at `http://www.open-scap.org/` and the repository for their tools and profiles is on GitHub at `https://github.com/OpenSCAP/openscap/`.
-Red Hat ships SCAP content in the SCAP security guide, but the content the OpenSCAP uses is under active development and latest versions of it can be found at: `http://www.github.com/ComplianceAsCode`. 
+Red Hat ships SCAP content in the SCAP security guide, but the content the OpenSCAP uses is under active development and latest versions of it can be found at: `http://www.github.com/ComplianceAsCode`.  Red Hat also maintains security data feeds, including security advisories in OVAL format, at:  `https://access.redhat.com/security/data`.
 
 == Exercise Description
 
@@ -39,7 +39,7 @@ In the following exercises we'll use the CLI to show how you can validate system
 Ensure Apache httpd plus the OpenSCAP scanner and definitions are installed with the command below; it's safe to run even if the packages already exist:
 [source, bash]
 ----
-sudo yum install -y httpd openscap-scanner scap-security-guide
+sudo yum install -y httpd openscap-scanner openscap-utils scap-security-guide
 ----
  
 The ##scap-security-guide## package contains prepared system profiles for several RHEL releases and system types; they are installed under */usr/share/xml/scap/ssg/content*.  +
@@ -51,43 +51,68 @@ oscap info --fetch-remote-resources /usr/share/xml/scap/ssg/content/ssg-rhel8-ds
 Output:
 ....
 Document type: Source Data Stream
-Imported: 2020-02-11T13:41:17
+Imported: 2023-02-13T11:49:18
 
-Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel8-xccdf-1.2.xml
+Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel8-xccdf.xml
 Generated: (null)
 Version: 1.3
 Checklists:
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel8-xccdf-1.2.xml
-Downloading: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml ... ok
-                Status: draft
-                Generated: 2020-02-11
-                Resolved: true
-                Profiles:
-                        Title: Protection Profile for General Purpose Operating Systems
-                                Id: xccdf_org.ssgproject.content_profile_ospp
-                        Title: PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8
-                                Id: xccdf_org.ssgproject.content_profile_pci-dss
-                        Title: [DRAFT] DISA STIG for Red Hat Enterprise Linux 8
-                                Id: xccdf_org.ssgproject.content_profile_stig
-                        Title: Australian Cyber Security Centre (ACSC) Essential Eight
-                                Id: xccdf_org.ssgproject.content_profile_e8
-                Referenced check files:
-                        ssg-rhel8-oval.xml
-                                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
-                        ssg-rhel8-ocil.xml
-                                system: http://scap.nist.gov/schema/ocil/2
-                        security-data-oval-com.redhat.rhsa-RHEL8.xml
-                                system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-xccdf.xml
+Downloading: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2 ... ok
+		Status: draft
+		Generated: 2023-02-13
+		Resolved: true
+		Profiles:
+			Title: ANSSI-BP-028 (enhanced)
+				Id: xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced
+			Title: ANSSI-BP-028 (high)
+				Id: xccdf_org.ssgproject.content_profile_anssi_bp28_high
+			Title: ANSSI-BP-028 (intermediary)
+				Id: xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary
+			Title: ANSSI-BP-028 (minimal)
+				Id: xccdf_org.ssgproject.content_profile_anssi_bp28_minimal
+			Title: CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Server
+				Id: xccdf_org.ssgproject.content_profile_cis
+			Title: CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Server
+				Id: xccdf_org.ssgproject.content_profile_cis_server_l1
+			Title: CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation
+				Id: xccdf_org.ssgproject.content_profile_cis_workstation_l1
+			Title: CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Workstation
+				Id: xccdf_org.ssgproject.content_profile_cis_workstation_l2
+			Title: Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)
+				Id: xccdf_org.ssgproject.content_profile_cui
+			Title: Australian Cyber Security Centre (ACSC) Essential Eight
+				Id: xccdf_org.ssgproject.content_profile_e8
+			Title: Health Insurance Portability and Accountability Act (HIPAA)
+				Id: xccdf_org.ssgproject.content_profile_hipaa
+			Title: Australian Cyber Security Centre (ACSC) ISM Official
+				Id: xccdf_org.ssgproject.content_profile_ism_o
+			Title: Protection Profile for General Purpose Operating Systems
+				Id: xccdf_org.ssgproject.content_profile_ospp
+			Title: PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8
+				Id: xccdf_org.ssgproject.content_profile_pci-dss
+			Title: DISA STIG for Red Hat Enterprise Linux 8
+				Id: xccdf_org.ssgproject.content_profile_stig
+			Title: DISA STIG with GUI for Red Hat Enterprise Linux 8
+				Id: xccdf_org.ssgproject.content_profile_stig_gui
+		Referenced check files:
+			ssg-rhel8-oval.xml
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+			ssg-rhel8-ocil.xml
+				system: http://scap.nist.gov/schema/ocil/2
+			security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
 Checks:
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel8-oval.xml
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel8-ocil.xml
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-oval.xml
-        Ref-Id: scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-oval.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-ocil.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-oval.xml
+	Ref-Id: scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2
 Dictionaries:
-        Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-dictionary.xml
+	Ref-Id: scap_org.open-scap_cref_ssg-rhel8-cpe-dictionary.xml
+
 ....
 
-Looking about half-way down, you can see that this file contains two profiles:  one for PCI-DSS and another for OSPP.  The OSPP profile is a general-purpose profile, so it's a good choice for testing.
+Towards the bottom of the list, you can see profiles for PCI-DSS and another for OSPP.  The OSPP profile is a general-purpose profile, so it's a good choice for testing.
 
 
 == Section 2: Enable httpd for viewing compliance report
@@ -136,6 +161,11 @@ To correct compliance issues found in the scan, we can generate a Bash shell scr
 ----
 sudo oscap xccdf generate fix --fetch-remote-resources --fix-type ansible --result-id "" /tmp/arf.xml > /tmp/ospp-playbook-fix.yml
 ----
+
+[NOTE]
+The above example produces a tailored remediation playbook, but you can similarly generate a complete remediation playbook for any profile.  For example, to create a playbook to apply the DISA STIG, you would run:
+##sudo oscap xccdf generate fix --fetch-remote-resources --fix-type ansible --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml > /tmp/stig-playbook-fix.yml##
+
 
 Review the generated YAML file, ##/tmp/ospp-playbook-fix.yml##.  Note that the individual tasks are clearly named and delineated.  Once you're comfortable with it, run the playbook with:
 [source, bash]

--- a/content/workshops/rhel_8/exercise1.8.adoc
+++ b/content/workshops/rhel_8/exercise1.8.adoc
@@ -264,7 +264,8 @@ Alternatively, if you would prefer to stop only a single container, you can util
 podman stop 11fcab28fd31
 ----
 
-== Section 5: Use skopeo and podman to integrate the container into systemd
+
+== Section 6: Use skopeo and podman to integrate the container into systemd
 
 Running as ec2-user, the container work that you have done is stored in your home directory. We will move it to the system image store in /var/lib/, enable it and start the application.
 
@@ -300,7 +301,7 @@ skopeo inspect containers-storage:localhost/httpd
 }
 ....
 
-=== Step 2: Transfer the image into the operating system image store ====
+=== Step 2: Transfer the image into the operating system image store
 
 First export the image from ec2-user's image store into an archive file. Skopeo can export containers into either docker archive or OCI archive if we want to put the container into a file. Using the OCI archive format:
 
@@ -346,7 +347,38 @@ REPOSITORY        TAG      IMAGE ID       CREATED          SIZE
 localhost/httpd   latest   80dd2eb93b53   37 minutes ago   242 MB
 ....
 
-=== Step 3: Integrate container into systemd
+=== Step 3: Scan the container image for CVEs
+
+Before using this container image in a system service, let's check it for CVEs.  Since RHEL 8.2, the ##oscap-podman## utility has been included for scanning container images.  Let's see how this works!
+
+[NOTE]
+##oscap-podman## requires root privilege.
+
+==== Step 3a: Download the latest Red Hat Security Advisories
+
+Red Hat continuously updates security data feeds on ##https://access.redhat.com/security/data##.  Let's start by retrieving and decompressing the latest RHEL advisories in OVAL format:
+[source, bash]
+----
+curl https://www.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2 | bzip2 --decompress > rhel-8.oval.xml
+----
+
+==== Step 3b: Scan a container image with oscap-podman
+
+Pick an ##IMAGE ID## from the previous ##sudo podman images## output -- in this case, the httpd image -- and run the scan with:
+
+[source, bash]
+----
+sudo oscap-podman 80dd2eb93b53 oval eval --report /var/www/html/image-oval-report.html rhel-8.oval.xml
+----
+
+Once the command completes, open this link in another tab to view the resulting report:
+
+[source, bash]
+----
+{{< urifqdnrev "http://" "node" "/image-oval-report.html" >}}
+----
+
+=== Step 4: Integrate container into systemd
 
 To finish this section, let's integrate our new container into systemd so you can have it start at boot time and otherwise manage it using systemd. Before getting started, ensure that the webserver started in the openSCAP section is not running:
 

--- a/content/workshops/rhel_8/exercise1.9.adoc
+++ b/content/workshops/rhel_8/exercise1.9.adoc
@@ -13,18 +13,23 @@ layout: lab
 :var_prec_url: http://docs.ansible.com/ansible/latest/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable
 
 == Exercise Description
-RHEL 7.4 introduced RHEL System Roles, a collection of Ansible roles and modules that provide a stable and consistent configuration interface for remote management of Red Hat Enterprise Linux.  These System Roles are applicable to RHEL 6.10 and above, easing management of 3 generations of RHEL.  The effort is based on development of the Linux System Roles project (link: https://linux-system-roles.github.io/upstream). The following roles are provided and supported as follows:
+RHEL System Roles, announced with the launch of RHEL 8, are a collection of Ansible roles and modules that provide a stable and consistent configuration interface for remote management of Red Hat Enterprise Linux.  They address many commmon configuration, security and workload uses on RHEL systems.  These roles can manage systems running RHEL 7 and above, easing management of 3 generations of RHEL.  The effort is based on development of the Linux System Roles project (link: https://linux-system-roles.github.io/upstream).  These roles are fully supported by Red Hat, so make use of them and avoid duplication of effort in your automation endeavors.
 
-There are a number of roles available in RHEL 8, including:
+There are a number of roles available, including:
 
 * selinux
+* ssh & sshd
+* crypto_policy
 * kdump (kernel crash dump)
 * network
+* vpn
 * timesync
+* logging
 * storage
 * postfix
+* ha_cluster
 
-The full list can be found here: https://access.redhat.com/articles/3050101[Red Hat Enterprise Linux (RHEL) System Roles]
+The full list and compatibility matrix can be found here: https://access.redhat.com/articles/3050101[Red Hat Enterprise Linux (RHEL) System Roles]
 
 For further information on Ansible, see the Ansible Quick-Start Guide for Sysadmins (https://www.redhat.com/en/blog/system-administrators-guide-getting-started-ansible-fast) or Quick Start Video (https://www.ansible.com/resources/videos/quick-start-video) for help learning how to use Ansible.
 
@@ -51,7 +56,8 @@ And install the required packages:
 
 [source, bash]
 ----
-sudo yum install rhel-system-roles ansible
+sudo yum -y module install python36
+sudo yum -y install rhel-system-roles ansible
 ----
 
 == Step 2: Documentation
@@ -193,8 +199,11 @@ Now let's run our playbook to create a new connection profile called DBnic, turn
 
 [source, bash]
 ----
-ansible-playbook example-network-playbook.yml
+ansible-playbook --extra-vars "ansible_python_interpreter=/usr/bin/python3.6" example-network-playbook.yml
 ----
+
+[NOTE]
+Starting in RHEL 8.7, Python 3.9 is the default Python3 interpreter.
 
 ....
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


### PR DESCRIPTION
Updates for RHEL 8 workshop sections 1.7, 1.8 & 1.9.

Some minor refreshing, plus I added examples of using oscap-podman and more detail around generating auto-remediation playbooks.
One bit of errata, RHEL 8.7 now defaults to Python 3.9, and there is a missing dependency that affects the network role example in sect. 1.9.  I added steps to ensure the Python 3.6 stream was also installed and intentionally call it for the example.